### PR TITLE
Fixed command to install npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Dependencies
 
 #### [npm](http://npmjs.org/)
 
-    curl http://npmjs.org/install.sh | sh
+    curl https://npmjs.org/install.sh | sh
    
 #### [CoffeeScript](http://jashkenas.github.com/coffee-script/)
   


### PR DESCRIPTION
Fixed command to install npm. When I ran the command:
`curl http://npmjs.org/install.sh | sh`
I got an error: 'sh: 2: Syntax error: newline unexpected'.

The reason for this can be found at: https://github.com/isaacs/npm/issues/2675
The solution is to use https (instead of http) in the URL. This is what this pull request does.
